### PR TITLE
Remove commented out (latex) lines and code formatting

### DIFF
--- a/js/abstractFormatting.js
+++ b/js/abstractFormatting.js
@@ -30,7 +30,7 @@ var formatText = function(inputText) {
     return inputText;
 };
 
-
+// Removes lines commented out using % in latex
 var removeCommentedOutLines = function(inputText) {
     return inputText.replace(/^%.*$/mg, '');
 };


### PR DESCRIPTION
Hi,
nice tool! I added some basic functionallity to automatically remove commented out lines, that are commented out using '%' e.g.

``` latex
First great line that will be kept

% This is the commented out line that will be removed

Second great line that will be kept
```

I stumbled upon this when trying the abstract from my master's thesis.

I also fixed some formatting stuff along the way. fixjsstyle is actually pretty cool, used for the first time today.
